### PR TITLE
deps: use parking-lot to simplify condvar and mutex usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Switch to `parking_lot` from `std::sync`.
+- Fix potential deadlock in underlying synchronization primitives.
+
 ## 0.1.0 - 2018-12-08
 ### Added
 - Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "mio-anonymous-pipes"
+edition = "2018"
 version = "0.1.0"
 authors = ["David Hewitt"]
 license = "MIT"
@@ -11,3 +12,4 @@ mio = "0.6"
 miow = "0.3"
 winapi = { version = "0.3.5", features = ["ioapiset"] }
 spsc-buffer = "0.1"
+parking_lot = "0.11.1"


### PR DESCRIPTION
Switches to `parking_lot` instead of `std::sync` for `Mutex` and `Condvar`.

As it's really cheap to call `notify_one()` with no waiters when using `parking_lot()` (probably even cheaper than all the if-conditions had previously), just unconditionally call `notify_one()` in every read / write cycle. This should avoid deadlocks even futher beyond #1.